### PR TITLE
using file name as dir for sdk path

### DIFF
--- a/flutter.el
+++ b/flutter.el
@@ -138,8 +138,8 @@ ARGS is a space-delimited string of CLI flags passed to
 
 (defun flutter-build-command ()
   "Build flutter command to execute."
-  (let ((bin (when flutter-sdk-path (concat flutter-sdk-path "bin/"))))
-    (concat (or bin "") "flutter")))
+  (let ((bin (when flutter-sdk-path (concat (file-name-as-directory flutter-sdk-path) "bin"))))
+    (concat (if bin (file-name-as-directory bin) "") "flutter")))
 
 ;;;###autoload
 (defun flutter-run (&optional args)


### PR DESCRIPTION
1. make it compatible for the path without trailing slash
2. compatible for windows

I found that the flutter command is simply `concat`ing the `flutter-sdk-path` and `bin/`

this will not work for the case if tailing slack is missed for `flutter-sdk-path`
even this may not compatible for windows

So I was using the `file-name-as-directory` to replace the `flutter-sdk-path` and `bin`