### PR TITLE
Add tests command

### DIFF
--- a/flutter.el
+++ b/flutter.el
@@ -33,6 +33,7 @@
 (require 'flutter-l10n)
 
 (defconst flutter-buffer-name "*Flutter*")
+(defconst flutter-test-buffer-name "*Flutter Test*")
 
 (defvar flutter-sdk-path nil
   "Path to Flutter SDK.")
@@ -103,8 +104,9 @@ the `flutter` process."
        (error "Root of Flutter project not found"))))
 
 (defmacro flutter--with-run-proc (args &rest body)
-  "Execute BODY while ensuring an inferior `flutter` process is running.
+  "Execute BODY while ensuring an inferior `flutter run` process is running.
 
+BUFFER-NAME is the chosen buffer where will run the proc.
 ARGS is a space-delimited string of CLI flags passed to
 `flutter`, and can be nil."
   `(flutter--from-project-root
@@ -118,16 +120,51 @@ ARGS is a space-delimited string of CLI flags passed to
           (flutter-mode)))
       ,@body)))
 
+(defmacro flutter--with-test-proc (args &rest body)
+  "Execute BODY while ensuring an inferior `flutter test` process is running.
+
+BUFFER-NAME is the chosen buffer where will run the proc.
+ARGS is a space-delimited string of CLI flags passed to
+`flutter`, and can be nil."
+  `(flutter--from-project-root
+    (let* ((buffer (get-buffer-create flutter-test-buffer-name))
+           (alive (flutter--testing-p))
+           (arglist (when ,args (split-string ,args))))
+      (unless alive
+        (apply #'make-comint-in-buffer "Flutter Test" buffer (flutter-build-command) nil "test" arglist))
+      (with-current-buffer buffer
+        (unless (derived-mode-p 'flutter-mode)
+          (flutter-mode)))
+      ,@body)))
+
 (defun flutter--running-p ()
-  "Return non-nil if the `flutter` process is already running."
+  "Return non-nil if the `flutter run` process is already running."
   (comint-check-proc flutter-buffer-name))
+
+(defun flutter--testing-p ()
+  "Return non-nil if the `flutter test` process is already running."
+  (comint-check-proc flutter-test-buffer-name))
 
 (defun flutter--send-command (command)
   "Send COMMAND to a running Flutter process."
   (flutter--with-run-proc
+   flutter-buffer-name
    nil
    (let ((proc (get-buffer-process flutter-buffer-name)))
      (comint-send-string proc command))))
+
+(defun flutter--test (&optional args)
+  "Execute `flutter test` inside Emacs.
+
+ARGS is a space-delimited string of CLI flags passed to
+`flutter`, and can be nil.  Call with a prefix to be prompted for
+args."
+  (interactive
+   (list (when current-prefix-arg
+           (read-string "Args: "))))
+  (flutter--with-test-proc
+   args
+   (pop-to-buffer-same-window buffer)))
 
 (defun flutter--initialize ()
   "Helper function to initialize Flutter."
@@ -162,6 +199,12 @@ args."
   (if (flutter--running-p)
       (flutter-hot-reload)
     (flutter-run)))
+
+;;;###autoload
+(defun flutter-test-all ()
+  "Execute `flutter test` inside Emacs on project root."
+  (interactive)
+  (flutter--test))
 
 ;;;###autoload
 (define-derived-mode flutter-mode comint-mode "Flutter"

--- a/flutter.el
+++ b/flutter.el
@@ -103,7 +103,7 @@ the `flutter` process."
        (error "Root of Flutter project not found"))))
 
 (defmacro flutter--with-run-proc (args &rest body)
-  "Execute BODY while ensuring an inferior `flutter run` process is running.
+  "Execute BODY while ensuring an inferior `flutter` process is running.
 
 ARGS is a space-delimited string of CLI flags passed to
 `flutter`, and can be nil."
@@ -119,13 +119,12 @@ ARGS is a space-delimited string of CLI flags passed to
       ,@body)))
 
 (defun flutter--running-p ()
-  "Return non-nil if the `flutter run` process is already running."
+  "Return non-nil if the `flutter` process is already running."
   (comint-check-proc flutter-buffer-name))
 
 (defun flutter--send-command (command)
   "Send COMMAND to a running Flutter process."
   (flutter--with-run-proc
-   flutter-buffer-name
    nil
    (let ((proc (get-buffer-process flutter-buffer-name)))
      (comint-send-string proc command))))
@@ -134,13 +133,9 @@ ARGS is a space-delimited string of CLI flags passed to
   "Execute `flutter test` inside Emacs.
 
 ARGS is a space-delimited string of CLI flags passed to
-`flutter`, and can be nil.  Call with a prefix to be prompted for
-args."
-  (interactive
-   (list (when current-prefix-arg
-           (read-string "Args: "))))
+`flutter`, and can be nil."
   (flutter--from-project-root
-   (compilation-start (format "%s test %s" (flutter-build-command) args) t)))
+   (compilation-start (format "%s test %s" (flutter-build-command) (or args "")) t)))
 
 (defun flutter--initialize ()
   "Helper function to initialize Flutter."

--- a/flutter.el
+++ b/flutter.el
@@ -202,9 +202,16 @@ args."
 
 ;;;###autoload
 (defun flutter-test-all ()
-  "Execute `flutter test` inside Emacs on project root."
+  "Execute `flutter test` inside Emacs."
   (interactive)
   (flutter--test))
+
+;;;###autoload
+(defun flutter-test-current-file ()
+  "Execute `flutter test <current-file>` inside Emacs."
+  (interactive)
+  (let ((test-file (file-relative-name buffer-file-name (flutter-project-get-root))))
+    (flutter--test test-file)))
 
 ;;;###autoload
 (define-derived-mode flutter-mode comint-mode "Flutter"


### PR DESCRIPTION
Fix https://github.com/amake/flutter.el/issues/7

Adds 2 new commands:
* `flutter-test-all` - Run all tests from project root and display in a new buffer.
* `flutter-test-current-file` - Run tests from current file display in a new buffer.

This flutter test commands helps a lot, hope you like it too.

I'm thinking to add one more command `flutter-test-at-point`, running only the test on cursor, in other PR. 