### PR TITLE
Add flutter-args variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,5 +98,17 @@ put the Flutter SDK in `/Applications/flutter`:
   (flutter-sdk-path "/Applications/flutter/"))
 ```
 
+## .dir-locals.el
+
+`flutter-args` is used to set default CLI flags passed to `flutter`.
+This variable can be set per project using a `.dir-locals.el` file in project root.
+The following `.dir-locals.el` sets `flutter-args` to build linux executable and
+enables hot reloading on file save using `after-save-hook`.
+
+``` elisp
+((dart-mode . ((flutter-args . "-d linux")
+               (eval . (add-hook 'after-save-hook 'flutter-run-or-hot-reload nil t)))))
+```
+
 # License
 GPL-3

--- a/README.md
+++ b/README.md
@@ -98,17 +98,5 @@ put the Flutter SDK in `/Applications/flutter`:
   (flutter-sdk-path "/Applications/flutter/"))
 ```
 
-## .dir-locals.el
-
-`flutter-args` is used to set default CLI flags passed to `flutter`.
-This variable can be set per project using a `.dir-locals.el` file in project root.
-The following `.dir-locals.el` sets `flutter-args` to build linux executable and
-enables hot reloading on file save using `after-save-hook`.
-
-``` elisp
-((dart-mode . ((flutter-args . "-d linux")
-               (eval . (add-hook 'after-save-hook 'flutter-run-or-hot-reload nil t)))))
-```
-
 # License
 GPL-3

--- a/flutter.el
+++ b/flutter.el
@@ -38,8 +38,8 @@
 (defvar flutter-sdk-path nil
   "Path to Flutter SDK.")
 
-(defvar flutter-args nil
-  "Space-delimited string of CLI flags passed to `flutter`.")
+(defvar flutter-run-args nil
+  "Space-delimited string of CLI flags passed to `flutter-run'.")
 
 
 ;;; Key bindings
@@ -262,9 +262,7 @@ args."
    (list (when current-prefix-arg
            (read-string "Args: "))))
   (flutter--with-run-proc
-   (if args
-       args
-     flutter-args)
+   (or args flutter-run-args)
    (display-buffer buffer)))
 
 (defun flutter--devices ()

--- a/flutter.el
+++ b/flutter.el
@@ -38,6 +38,9 @@
 (defvar flutter-sdk-path nil
   "Path to Flutter SDK.")
 
+(defvar flutter-args nil
+  "Space-delimited string of CLI flags passed to `flutter`.")
+
 
 ;;; Key bindings
 
@@ -259,7 +262,9 @@ args."
    (list (when current-prefix-arg
            (read-string "Args: "))))
   (flutter--with-run-proc
-   args
+   (if flutter-args
+       flutter-args
+     args)
    (display-buffer buffer)))
 
 (defun flutter--devices ()

--- a/flutter.el
+++ b/flutter.el
@@ -262,9 +262,9 @@ args."
    (list (when current-prefix-arg
            (read-string "Args: "))))
   (flutter--with-run-proc
-   (if flutter-args
-       flutter-args
-     args)
+   (if args
+       args
+     flutter-args)
    (display-buffer buffer)))
 
 (defun flutter--devices ()


### PR DESCRIPTION
I was going to write an Emacs package for interacting with Flutter. Luckily I googled it and stumbled upon your package. Awesome package, very useful when working with Flutter. I have set `after-save-hook` to `flutter-run-or-hot-reload` which makes it hot reload on save, and everything is working smoothly. 

The only thing I missed was a way to specify default flags to pass to Flutter. I am working with several projects, some web and some linux. When running flutter I had to `C-u M-x flutter-run` in order to add `-d linux`. With this commit it can be specified in `.dir-locals.el` and therefore set on a per-project basis. I've added a note about this to the readme.

This commit should not break existing functionality as `flutter-args` is set to nil by default, and then not used in `flutter-run`. 

What do you think? Is this something you could consider adding? 

Again, thanks for this package ! 