### PR TITLE
Don't throw error from flutter-l10n-flycheck workdir function

### DIFF
--- a/flutter-l10n-flycheck.el
+++ b/flutter-l10n-flycheck.el
@@ -44,7 +44,7 @@
   :command ("flutter" "packages" "pub"
             "run" "intl_translation:extract_to_arb"
             source)
-  :working-directory (lambda (_) (flutter-project-get-root))
+  :working-directory (lambda (_) (ignore-errors (flutter-project-get-root)))
   :modes (dart-mode)
   :enabled flutter-l10n-flycheck--enable-p
   :error-patterns


### PR DESCRIPTION
Throwing an error from the working-directory function leads to freezes in buffers that produce an error.
`(flutter-project-get-root)` throws an error when the project is not a flutter project.
This change fixes the freezes experienced in `dart-mode` buffers for files that are not part of a flutter project.